### PR TITLE
fix(race): delay drive status check to allow proper car animation

### DIFF
--- a/src/components/CarItem/CarItemContainer.tsx
+++ b/src/components/CarItem/CarItemContainer.tsx
@@ -1,137 +1,148 @@
-import React, { useRef, useState, useEffect } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import React, {useRef, useState, useEffect} from 'react';
+import {useDispatch, useSelector} from 'react-redux';
 
-import type { RootState, AppDispatch } from '../../redux/store';
-import type { CarState } from '../../redux/slices/raceSlice';
+import type {RootState, AppDispatch} from '../../redux/store';
 import {
-  drive,
-  finishCar,
-  setCarAnimationId,
-  startEngine,
-  stopEngine,
-  stopRace,
+    drive,
+    finishCar,
+    setCarAnimationId,
+    startEngine,
+    stopEngine,
 } from '../../redux/slices/raceSlice';
-import { saveWinner } from '../../redux/slices/winnersSlice';
+import {saveWinner} from '../../redux/slices/winnersSlice';
 
 import CarItem from './CarItem';
-import type { OwnProps } from './car_item_types';
+import type {OwnProps} from './car_item_types';
+
 const SECOND_IN_MS = 1000;
 const DISTANCE_PX = 500;
+const DRIVE_CHECK_DELAY = 1000;
 
 type Props = OwnProps;
 
 const CarItemContainer: React.FC<Props> = ({
-  carInfo,
-  onSelect,
-  onDelete,
-  isSelected,
-  disabled,
-}) => {
-  const dispatch = useDispatch<AppDispatch>();
+                                               carInfo,
+                                               onSelect,
+                                               onDelete,
+                                               isSelected,
+                                               disabled,
+                                           }) => {
+    const dispatch = useDispatch<AppDispatch>();
 
-  const isRacing = useSelector((state: RootState) => state.race.isRacing);
-  const car = useSelector((state: RootState) =>
-    state.race.carsState.find((c: CarState) => c.id === carInfo.id)
-  );
+    const isRacing = useSelector((state: RootState) => state.race.isRacing);
+    const carRef = useRef<HTMLDivElement>(null);
+    const [isBroken, setBroken] = useState(false);
+    const [isDriving, setIsDriving] = useState(false);
+    const [currentAnimationId, setCurrentAnimationId] = useState<number | undefined>();
 
-  const carRef = useRef<HTMLDivElement>(null);
-  const [isBroken, setBroken] = useState(false);
-  const [isDriving, setIsDriving] = useState(false);
-
-  useEffect(() => {
-    return (): void => {
-      if (car?.animationId) cancelAnimationFrame(car.animationId);
-    };
-  }, [car?.animationId]);
-
-  useEffect(() => {
-    if (!isRacing) stopCarAndReset();
-    else startCar();
-  }, [isRacing]);
-
-  const startCar = async (): Promise<void> => {
-    try {
-      if (isBroken) setBroken(false);
-      setIsDriving(true);
-
-      const engineAction = await dispatch(startEngine(carInfo.id)).unwrap();
-      const driveAction = await dispatch(drive(carInfo.id)).unwrap();
-
-      if (driveAction.success && carRef.current) {
-        const distancePx = carRef.current.parentElement?.offsetWidth || DISTANCE_PX;
-        const duration = (engineAction.distance / engineAction.velocity) * SECOND_IN_MS;
-        const startTime = performance.now();
-
-        const animate = (timestamp: number): void => {
-          const elapsed = timestamp - startTime;
-          const progress = Math.min(elapsed / duration, 1);
-
-          if (carRef.current) {
-            carRef.current.style.transform = `translateX(${progress * distancePx}px)`;
-          }
-
-          if (progress < 1) {
-            const id = requestAnimationFrame(animate);
-            dispatch(setCarAnimationId({ id: carInfo.id, animationId: id }));
-          } else {
-            dispatch(finishCar({ id: carInfo.id }));
-            dispatch(saveWinner({ carId: carInfo.id, time: duration / SECOND_IN_MS }));
-            dispatch(stopRace());
-            setIsDriving(false);
-            stopCarAndReset();
-          }
+    useEffect(() => {
+        return (): void => {
+            if (currentAnimationId) cancelAnimationFrame(currentAnimationId);
         };
+    }, [currentAnimationId]);
 
-        const id = requestAnimationFrame(animate);
-        dispatch(setCarAnimationId({ id: carInfo.id, animationId: id }));
-      } else {
+    useEffect(() => {
+        if (!isRacing) stopCarAndReset();
+        else startCar();
+    }, [isRacing]);
+
+    const startCar = async (): Promise<void> => {
+        try {
+            if (isBroken) setBroken(false);
+            setIsDriving(true);
+            const engineAction = await dispatch(startEngine(carInfo.id)).unwrap();
+            if (engineAction && carRef.current) {
+                const distancePx = carRef.current.parentElement?.offsetWidth || DISTANCE_PX;
+                const duration = (engineAction.distance / engineAction.velocity) * SECOND_IN_MS;
+                const startTime = performance.now();
+
+                const animate = (timestamp: number): void => {
+                    const elapsed = timestamp - startTime;
+                    const progress = Math.min(elapsed / duration, 1);
+
+                    if (carRef.current) {
+                        carRef.current.style.transform = `translateX(${progress * distancePx}px)`;
+                    }
+
+                    if (progress < 1) {
+                        const id = requestAnimationFrame(animate);
+                        setCurrentAnimationId(id);
+                        dispatch(setCarAnimationId({id: carInfo.id, animationId: id}));
+                    } else {
+                        dispatch(finishCar({id: carInfo.id}));
+                        dispatch(saveWinner({carId: carInfo.id, time: duration / SECOND_IN_MS}));
+                        setIsDriving(false);
+                    }
+                };
+
+                const id = requestAnimationFrame(animate);
+                setCurrentAnimationId(id);
+                dispatch(setCarAnimationId({id: carInfo.id, animationId: id}));
+                setTimeout(() => {
+                    checkDriveStatus();
+                }, DRIVE_CHECK_DELAY);
+            }
+        } catch (error) {
+            setIsDriving(false);
+            setBroken(true);
+        }
+    };
+
+    const checkDriveStatus = async (): Promise<void> => {
+        try {
+            const driveAction = await dispatch(drive(carInfo.id)).unwrap();
+            if (!driveAction.success) {
+                stopCarDueToFailure();
+            }
+        } catch {
+            stopCarDueToFailure();
+        }
+    };
+
+    const stopCarDueToFailure = (): void => {
+        if (currentAnimationId) {
+            cancelAnimationFrame(currentAnimationId);
+            setCurrentAnimationId(undefined);
+            dispatch(setCarAnimationId({id: carInfo.id, animationId: undefined}));
+        }
         setIsDriving(false);
         setBroken(true);
-      }
-    } catch {
-      setIsDriving(false);
-      setBroken(true);
-    }
-  };
+    };
 
-  const stopCarAndReset = async (): Promise<void> => {
-    // If stopEngine is a thunk, unwrap to surface errors; otherwise just await dispatch(...)
-    try {
-      await dispatch(stopEngine(carInfo.id)).unwrap();
-    } catch {
-      // ignore stop error for reset flow
-    }
+    const stopCarAndReset = async (): Promise<void> => {
+        await dispatch(stopEngine(carInfo.id)).unwrap();
 
-    if (car?.animationId) {
-      cancelAnimationFrame(car.animationId);
-      dispatch(setCarAnimationId({ id: carInfo.id, animationId: undefined }));
-    }
-    if (carRef.current) carRef.current.style.transform = `translateX(0)`;
-    setIsDriving(false);
-    setBroken(false);
-  };
+        if (currentAnimationId) {
+            cancelAnimationFrame(currentAnimationId);
+            setCurrentAnimationId(undefined);
+            dispatch(setCarAnimationId({id: carInfo.id, animationId: undefined}));
+        }
+        if (carRef.current) carRef.current.style.transform = `translateX(0)`;
+        setIsDriving(false);
+        setBroken(false);
+    };
 
-  const stopCarManually = async (): Promise<void> => {
-    await stopCarAndReset();
-    setBroken(false);
-    setIsDriving(false);
-  };
+    const stopCarManually = async (): Promise<void> => {
+        await stopCarAndReset();
+        setBroken(false);
+        setIsDriving(false);
+    };
 
-  return (
-    <CarItem
-      carInfo={carInfo}
-      onSelect={onSelect}
-      onDelete={onDelete}
-      isSelected={isSelected}
-      disabled={disabled}
-      carRef={carRef}
-      isBroken={isBroken}
-      isRacing={isRacing}
-      isDriving={isDriving}
-      startCar={startCar}
-      stopCarManually={stopCarManually}
-    />
-  );
+    return (
+        <CarItem
+            carInfo={carInfo}
+            onSelect={onSelect}
+            onDelete={onDelete}
+            isSelected={isSelected}
+            disabled={disabled}
+            carRef={carRef}
+            isBroken={isBroken}
+            isRacing={isRacing}
+            isDriving={isDriving}
+            startCar={startCar}
+            stopCarManually={stopCarManually}
+        />
+    );
 };
 
 export default CarItemContainer;


### PR DESCRIPTION
- Ensured cars begin moving immediately on race start, only stopping mid-race if drive fails later
- Fixed issue where drive failures appeared to break cars immediately at start instead of during race